### PR TITLE
Add foreign server health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,32 @@ but other users can be granted EXECUTE to run the function.
 
 The caller of this function must be a superuser or a user having
 memberships of all users having valid user mappings to all defined servers.
+
+### boolean pgfdw_plus_verify_connection_states(server_name text)
+Checks the status of remote connections established by postgres_fdw from the
+local session to the foreign server with the given name. This check is performed
+by polling the socket and allows long-running transactions to be aborted sooner
+if the kernel reports that the connection is closed. This function is currently
+available only on systems that support the non-standard POLLRDHUP extension to
+the poll system call, including Linux. This returns true if existing connection
+is not closed by the remote peer. false is returned if the local session seems
+to be disconnected from other servers. NULL is returned if a valid connection
+to the specified foreign server is not established or this function is not
+available on this platform. If no foreign server with the given name is found,
+an error is reported.
+
+### boolean pgfdw_plus_verify_connection_states_all()
+Checks the status of all the remote connections established by postgres_fdw
+from the local session to the foreign servers. This check is performed by
+polling the socket and allows long-running transactions to be aborted sooner if
+the kernel reports that the connection is closed. This function is currently
+available only on systems that support the non-standard POLLRDHUP extension to
+the poll system call, including Linux. This returns true if all connections are
+not closed by the remote peer. false is returned if the local session seems to
+be disconnected from at least one remote server. NULL is returned if no valid
+connections are established or this function is not available on this platform.
+
+### boolean pgfdw_plus_can_verify_connection_states()
+This function checks whether pgfdw_plus_verify_connection_states and
+pgfdw_plus_verify_connection_states_all work well or not. This returns true if
+it can be used, otherwise returns false.

--- a/README.md
+++ b/README.md
@@ -166,14 +166,16 @@ memberships of all users having valid user mappings to all defined servers.
 Checks the status of remote connections established by postgres_fdw from the
 local session to the foreign server with the given name. This check is performed
 by polling the socket and allows long-running transactions to be aborted sooner
-if the kernel reports that the connection is closed. This function is currently
-available only on systems that support the non-standard POLLRDHUP extension to
-the poll system call, including Linux. This returns true if existing connection
-is not closed by the remote peer. false is returned if the local session seems
-to be disconnected from other servers. NULL is returned if a valid connection
-to the specified foreign server is not established. If no foreign server with
-the given name is found or this function is not supported on this platform,
-an error is reported.
+if the kernel reports that the connection is closed.
+
+This function is currently available only on systems that support the
+non-standard POLLRDHUP extension to the poll system call, including Linux.
+
+This function returns true if existing connection is not closed by the remote
+peer. false is returned if the local session seems to be disconnected from other
+servers. NULL is returned if a valid connection to the specified foreign server
+is not established. If no foreign server with the given name is found or this
+function is not supported on this platform, an error is reported.
 
 ### boolean pgfdw_plus_can_verify_connection_states()
 This function checks whether pgfdw_plus_verify_connection_states works well or

--- a/README.md
+++ b/README.md
@@ -175,18 +175,6 @@ to the specified foreign server is not established or this function is not
 available on this platform. If no foreign server with the given name is found,
 an error is reported.
 
-### boolean pgfdw_plus_verify_connection_states_all()
-Checks the status of all the remote connections established by postgres_fdw
-from the local session to the foreign servers. This check is performed by
-polling the socket and allows long-running transactions to be aborted sooner if
-the kernel reports that the connection is closed. This function is currently
-available only on systems that support the non-standard POLLRDHUP extension to
-the poll system call, including Linux. This returns true if all connections are
-not closed by the remote peer. false is returned if the local session seems to
-be disconnected from at least one remote server. NULL is returned if no valid
-connections are established or this function is not available on this platform.
-
 ### boolean pgfdw_plus_can_verify_connection_states()
-This function checks whether pgfdw_plus_verify_connection_states and
-pgfdw_plus_verify_connection_states_all work well or not. This returns true if
-it can be used, otherwise returns false.
+This function checks whether pgfdw_plus_verify_connection_states works well or
+not. This returns true if it can be used, otherwise returns false.

--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ available only on systems that support the non-standard POLLRDHUP extension to
 the poll system call, including Linux. This returns true if existing connection
 is not closed by the remote peer. false is returned if the local session seems
 to be disconnected from other servers. NULL is returned if a valid connection
-to the specified foreign server is not established or this function is not
-available on this platform. If no foreign server with the given name is found,
+to the specified foreign server is not established. If no foreign server with
+the given name is found or this function is not supported on this platform,
 an error is reported.
 
 ### boolean pgfdw_plus_can_verify_connection_states()

--- a/connection.c
+++ b/connection.c
@@ -34,10 +34,6 @@
 #include "utils/memutils.h"
 #include "utils/syscache.h"
 
-#ifdef HAVE_POLL_H
-#include <poll.h>
-#endif
-
 #ifdef NOT_USED_IN_PGFDWPLUS
 /*
  * Connection cache hash table entry
@@ -96,9 +92,6 @@ static bool xact_got_connection = false;
 PG_FUNCTION_INFO_V1(postgres_fdw_get_connections);
 PG_FUNCTION_INFO_V1(postgres_fdw_disconnect);
 PG_FUNCTION_INFO_V1(postgres_fdw_disconnect_all);
-PG_FUNCTION_INFO_V1(pgfdw_plus_verify_connection_states);
-PG_FUNCTION_INFO_V1(pgfdw_plus_verify_connection_states_all);
-PG_FUNCTION_INFO_V1(pgfdw_plus_can_verify_connection_states);
 
 /* prototypes of private functions */
 static void make_new_connection(ConnCacheEntry *entry, UserMapping *user);
@@ -133,9 +126,6 @@ static void pgfdw_finish_pre_subcommit_cleanup(List *pending_entries,
 											   int curlevel);
 static bool UserMappingPasswordRequired(UserMapping *user);
 static bool disconnect_cached_connections(Oid serverid);
-static bool connection_checkable();
-static int check_connection_health(PGconn *conn);
-static bool verify_cached_connections(Oid serverid, bool *checked);
 
 /*
  * Get a PGconn which can be used to execute queries on the remote PostgreSQL
@@ -1883,214 +1873,4 @@ disconnect_cached_connections(Oid serverid)
 	}
 
 	return result;
-}
-
-/*
- * Check whether check_connection_health() can work on this platform.
- *
- * This function returns true if this platform can use check_connection_health(),
- * otherwise false.
- */
-static bool
-connection_checkable()
-{
-#if defined(HAVE_POLL) && defined(POLLRDHUP)
-	return true;
-#else
-	return false;
-#endif
-}
-
-/*
- * Check whether the socket peer closed the connection or not.
- *
- * This function returns >0 if the remote peer closed the connection, 0 if
- * disconnection is not detected or this function is not supported on this
- * platform, -1 if an error occurred.
- */
-static int
-check_connection_health(PGconn *conn)
-{
-#if defined(HAVE_POLL) && defined(POLLRDHUP)
-	struct	pollfd input_fd;
-	int		sock = PQsocket(conn);
-	int		result;
-	int		errflags = POLLERR | POLLHUP | POLLNVAL;
-
-	if (conn == NULL || sock == PGINVALID_SOCKET)
-		return -1;
-
-	input_fd.fd = sock;
-	input_fd.events = POLLRDHUP;
-
-	do
-		result = poll(&input_fd, 1, 0);
-	while (result < 0 && errno == EINTR);
-
-	/* revents field is filld, but error state */
-	if (result > 0 && (input_fd.revents & errflags))
-		return -1;
-
-	return result;
-#else
-	return 0;
-#endif
-}
-
-/*
- * Workhorse to verify cached connections.
- *
- * This function scans all the connection cache entries and verifies the
- * connections whose foreign server OID matches with the specified one. If
- * InvalidOid is specified, it verifies all the cached connections.
- *
- * This function emits warnings if a disconnection is found. This returns false
- * if disconnections are found, otherwise returns true.
- *
- * checked will be set to true if check_connection_health() is called at least once.
- */
-static bool
-verify_cached_connections(Oid serverid, bool *checked)
-{
-	HASH_SEQ_STATUS scan;
-	ConnCacheEntry *entry;
-	bool		all = !OidIsValid(serverid);
-	bool		result = true;
-	StringInfoData str;
-
-	*checked = false;
-
-	Assert(ConnectionHash);
-
-	hash_seq_init(&scan, ConnectionHash);
-	while ((entry = (ConnCacheEntry *) hash_seq_search(&scan)))
-	{
-		/* Ignore cache entry if no open connection right now */
-		if (!entry->conn)
-			continue;
-
-		/* Skip if the entry is invalidated */
-		if (entry->invalidated)
-			continue;
-
-		if (all || entry->serverid == serverid)
-		{
-			if (check_connection_health(entry->conn))
-			{
-				/* A foreign server might be down, so construct a message */
-				ForeignServer *server = GetForeignServer(entry->serverid);
-
-				if (result)
-				{
-					/*
-					 * Initialize and add a prefix if this is the first
-					 * disconnection we found.
-					 */
-					initStringInfo(&str);
-					appendStringInfo(&str, "could not connect to server ");
-
-					result = false;
-				}
-				else
-					appendStringInfo(&str, ", ");
-
-				appendStringInfo(&str, "\"%s\"", server->servername);
-			}
-
-			/* Set a flag to notify the caller */
-			*checked = true;
-		}
-	}
-
-	/* Raise a warning if disconnections are found */
-	if (!result)
-	{
-		Assert(str.len);
-		ereport(WARNING,
-				errcode(ERRCODE_CONNECTION_FAILURE),
-				errmsg("%s", str.data),
-				errdetail("Connection close is detected."),
-				errhint("Plsease check the health of server."));
-		pfree(str.data);
-	}
-
-	return result;
-}
-
-/*
- * Verify the specified cached connections.
- *
- * This function verifies the connections that are established by postgres_fdw
- * from the local session to the foreign server with the given name.
- *
- * This function emits a warning if a disconnection is found. This returns true
- * if existing connection is not closed by the remote peer. false is returned
- * if the local session seems to be disconnected from other servers. NULL is
- * returned if a valid connection to the specified foreign server is not
- * established or this function is not available on this platform.
- */
-Datum
-pgfdw_plus_verify_connection_states(PG_FUNCTION_ARGS)
-{
-	ForeignServer *server;
-	char	   *servername;
-	bool		result;
-	bool		checked = false;
-
-	/* quick exit if the checking does not work well on this platfrom */
-	if (!connection_checkable())
-		PG_RETURN_NULL();
-
-	/* quick exit if connection cache has not been initialized yet */
-	if (!ConnectionHash)
-		PG_RETURN_NULL();
-
-	servername = text_to_cstring(PG_GETARG_TEXT_PP(0));
-	server = GetForeignServerByName(servername, false);
-
-	result = verify_cached_connections(server->serverid, &checked);
-
-	/* Return the result if checking function was called, otherwise NULL */
-	if (checked)
-		PG_RETURN_BOOL(result);
-	else
-		PG_RETURN_NULL();
-}
-
-/*
- * Verify all the cached connections.
- *
- * This function verifies all the connections that are established by postgres_fdw
- * from the local session to the foreign servers.
- */
-Datum
-pgfdw_plus_verify_connection_states_all(PG_FUNCTION_ARGS)
-{
-	bool		result;
-	bool		checked = false;
-
-	/* quick exit if the checking does not work well on this platfrom */
-	if (!connection_checkable())
-		PG_RETURN_NULL();
-
-	/* quick exit if connection cache has not been initialized yet */
-	if (!ConnectionHash)
-		PG_RETURN_NULL();
-
-	result = verify_cached_connections(InvalidOid, &checked);
-
-	/* Return the result if checking function was called, otherwise NULL */
-	if (checked)
-		PG_RETURN_BOOL(result);
-	else
-		PG_RETURN_NULL();
-}
-
-/*
- * Check whether functions for verifying cached connections work well or not
- */
-Datum
-pgfdw_plus_can_verify_connection_states(PG_FUNCTION_ARGS)
-{
-	PG_RETURN_BOOL(connection_checkable());
 }

--- a/expected/postgres_fdw_plus.out
+++ b/expected/postgres_fdw_plus.out
@@ -671,6 +671,67 @@ DETAIL:  Error message: password is required
 (1 row)
 
 -- ===================================================================
+-- test for pgfdw_plus_verify_connection_states function
+-- ===================================================================
+-- -- The text of the error might vary across platforms, so only show SQLSTATE.
+\set VERBOSITY sqlstate
+-- Disconnect once and set application_name to an arbitrary value
+SELECT 1 FROM postgres_fdw_disconnect_all();
+ ?column? 
+----------
+        1
+(1 row)
+
+ALTER SERVER pgfdw_plus_loopback1 OPTIONS (SET application_name 'healthcheck');
+-- Define procedure for testing verify functions
+CREATE PROCEDURE test_verify_function(use_all boolean) AS $$
+DECLARE
+	can_verify boolean;
+	result boolean;
+BEGIN
+	PERFORM 1 FROM ft1 LIMIT 1;
+
+	-- Terminate the remote backend process
+	PERFORM pg_terminate_backend(pid, 180000) FROM pg_stat_activity
+		WHERE application_name = 'healthcheck';
+
+	-- Check whether we can do health check on this platform
+	SELECT INTO can_verify pgfdw_plus_can_verify_connection_states();
+
+	-- If the checking can be done on this platform, call it
+	IF can_verify IS TRUE THEN
+		-- Set client_min_messages to ERROR temporary because the following
+		-- function only throws a WARNING on the supported platform.
+		SET LOCAL client_min_messages TO ERROR;
+
+		IF use_all IS TRUE THEN
+			SELECT INTO result pgfdw_plus_verify_connection_states_all();
+		ELSE
+			SELECT INTO result pgfdw_plus_verify_connection_states('pgfdw_plus_loopback1');
+		END IF;
+
+		RESET client_min_messages;
+	ELSE
+		result = false;
+	END IF;
+
+	-- If result is FALSE, we succeeded to detect the disconnection or it could
+	-- not be done on this platform. Raise an message.
+	IF result IS FALSE THEN
+		RAISE INFO 'pgfdw_plus_verify_connection_states_all() could detect the disconnection, or health check cannot be used on this platform';
+	END IF;
+END;
+$$ LANGUAGE plpgsql;
+-- ..And call above function
+CALL test_verify_function(false);
+INFO:  00000
+ERROR:  08006
+CALL test_verify_function(true);
+INFO:  00000
+ERROR:  08006
+-- Clean up
+\set VERBOSITY default
+-- ===================================================================
 -- Reset global settings
 -- ===================================================================
 RESET postgres_fdw.two_phase_commit;

--- a/expected/postgres_fdw_plus.out
+++ b/expected/postgres_fdw_plus.out
@@ -684,7 +684,7 @@ SELECT 1 FROM postgres_fdw_disconnect_all();
 
 ALTER SERVER pgfdw_plus_loopback1 OPTIONS (SET application_name 'healthcheck');
 -- Define procedure for testing verify functions
-CREATE PROCEDURE test_verify_function(use_all boolean) AS $$
+DO $$
 DECLARE
 	can_verify boolean;
 	result boolean;
@@ -703,13 +703,7 @@ BEGIN
 		-- Set client_min_messages to ERROR temporary because the following
 		-- function only throws a WARNING on the supported platform.
 		SET LOCAL client_min_messages TO ERROR;
-
-		IF use_all IS TRUE THEN
-			SELECT INTO result pgfdw_plus_verify_connection_states_all();
-		ELSE
-			SELECT INTO result pgfdw_plus_verify_connection_states('pgfdw_plus_loopback1');
-		END IF;
-
+		SELECT INTO result pgfdw_plus_verify_connection_states('pgfdw_plus_loopback1');
 		RESET client_min_messages;
 	ELSE
 		result = false;
@@ -718,15 +712,10 @@ BEGIN
 	-- If result is FALSE, we succeeded to detect the disconnection or it could
 	-- not be done on this platform. Raise an message.
 	IF result IS FALSE THEN
-		RAISE INFO 'pgfdw_plus_verify_connection_states_all() could detect the disconnection, or health check cannot be used on this platform';
+		RAISE INFO 'pgfdw_plus_verify_connection_states() detected the disconnection, or health check cannot be used on this platform';
 	END IF;
 END;
 $$ LANGUAGE plpgsql;
--- ..And call above function
-CALL test_verify_function(false);
-INFO:  00000
-ERROR:  08006
-CALL test_verify_function(true);
 INFO:  00000
 ERROR:  08006
 -- Clean up

--- a/postgres_fdw_plus--1.0.sql
+++ b/postgres_fdw_plus--1.0.sql
@@ -504,14 +504,6 @@ AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT PARALLEL RESTRICTED;
 
 /*
- * Check the health of the connection to all servers.
- */
-CREATE FUNCTION pgfdw_plus_verify_connection_states_all ()
-RETURNS bool
-AS 'MODULE_PATHNAME'
-LANGUAGE C STRICT PARALLEL RESTRICTED;
-
-/*
  * Return true if connection check is supported on this platform.
  */
 CREATE FUNCTION pgfdw_plus_can_verify_connection_states ()

--- a/postgres_fdw_plus--1.0.sql
+++ b/postgres_fdw_plus--1.0.sql
@@ -490,3 +490,31 @@ BEGIN
     WHERE xc.fxid < r.fxmin AND xc.umids <@ r.umids RETURNING *;
 END;
 $$ LANGUAGE plpgsql;
+
+/*
+ * The object definitions for connection check.
+ */
+
+/*
+ * Check the health of the connection to given server.
+ */
+CREATE FUNCTION pgfdw_plus_verify_connection_states (text)
+RETURNS bool
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT PARALLEL RESTRICTED;
+
+/*
+ * Check the health of the connection to all servers.
+ */
+CREATE FUNCTION pgfdw_plus_verify_connection_states_all ()
+RETURNS bool
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT PARALLEL RESTRICTED;
+
+/*
+ * Return true if connection check is supported on this platform.
+ */
+CREATE FUNCTION pgfdw_plus_can_verify_connection_states ()
+RETURNS bool
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT PARALLEL SAFE;

--- a/postgres_fdw_plus.c
+++ b/postgres_fdw_plus.c
@@ -70,7 +70,6 @@ HTAB *ConnectionHash = NULL;
  * SQL functions
  */
 PG_FUNCTION_INFO_V1(pgfdw_plus_verify_connection_states);
-PG_FUNCTION_INFO_V1(pgfdw_plus_verify_connection_states_all);
 PG_FUNCTION_INFO_V1(pgfdw_plus_can_verify_connection_states);
 
 bool
@@ -698,35 +697,6 @@ pgfdw_plus_verify_connection_states(PG_FUNCTION_ARGS)
 	server = GetForeignServerByName(servername, false);
 
 	result = verify_cached_connections(server->serverid, &checked);
-
-	/* Return the result if checking function was called, otherwise NULL */
-	if (checked)
-		PG_RETURN_BOOL(result);
-	else
-		PG_RETURN_NULL();
-}
-
-/*
- * Verify all the cached connections.
- *
- * This function verifies all the connections that are established by postgres_fdw
- * from the local session to the foreign servers.
- */
-Datum
-pgfdw_plus_verify_connection_states_all(PG_FUNCTION_ARGS)
-{
-	bool		result;
-	bool		checked = false;
-
-	/* quick exit if the checking does not work well on this platfrom */
-	if (!connection_checkable())
-		PG_RETURN_NULL();
-
-	/* quick exit if connection cache has not been initialized yet */
-	if (!ConnectionHash)
-		PG_RETURN_NULL();
-
-	result = verify_cached_connections(InvalidOid, &checked);
 
 	/* Return the result if checking function was called, otherwise NULL */
 	if (checked)

--- a/postgres_fdw_plus.c
+++ b/postgres_fdw_plus.c
@@ -4,10 +4,15 @@
 #include "catalog/indexing.h"
 #include "catalog/namespace.h"
 #include "postgres_fdw_plus.h"
+#include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 #include "utils/xid8.h"
+
+#ifdef HAVE_POLL_H
+#include <poll.h>
+#endif
 
 /*
  * GUC parameters
@@ -60,6 +65,13 @@ DefineCustomVariablesForPgFdwPlus(void)
  * Connection cache (initialized on first use)
  */
 HTAB *ConnectionHash = NULL;
+
+/*
+ * SQL functions
+ */
+PG_FUNCTION_INFO_V1(pgfdw_plus_verify_connection_states);
+PG_FUNCTION_INFO_V1(pgfdw_plus_verify_connection_states_all);
+PG_FUNCTION_INFO_V1(pgfdw_plus_can_verify_connection_states);
 
 bool
 pgfdw_exec_cleanup_query_begin(ConnCacheEntry *entry, const char *query)
@@ -520,4 +532,214 @@ pgfdw_insert_xact_commits(List *umids)
 	CatalogTupleInsert(rel, tup);
 
 	table_close(rel, NoLock);
+}
+
+/*
+ * Check whether check_connection_health() can work on this platform.
+ *
+ * This function returns true if this platform can use check_connection_health(),
+ * otherwise false.
+ */
+bool
+connection_checkable()
+{
+#if defined(HAVE_POLL) && defined(POLLRDHUP)
+	return true;
+#else
+	return false;
+#endif
+}
+
+/*
+ * Check whether the socket peer closed the connection or not.
+ *
+ * This function returns >0 if the remote peer closed the connection, 0 if
+ * disconnection is not detected or this function is not supported on this
+ * platform, -1 if an error occurred.
+ */
+int
+check_connection_health(PGconn *conn)
+{
+#if defined(HAVE_POLL) && defined(POLLRDHUP)
+	struct	pollfd input_fd;
+	int		sock = PQsocket(conn);
+	int		result;
+	int		errflags = POLLERR | POLLHUP | POLLNVAL;
+
+	if (conn == NULL || sock == PGINVALID_SOCKET)
+		return -1;
+
+	input_fd.fd = sock;
+	input_fd.events = POLLRDHUP;
+
+	do
+		result = poll(&input_fd, 1, 0);
+	while (result < 0 && errno == EINTR);
+
+	/* revents field is filld, but error state */
+	if (result > 0 && (input_fd.revents & errflags))
+		return -1;
+
+	return result;
+#else
+	return 0;
+#endif
+}
+
+/*
+ * Workhorse to verify cached connections.
+ *
+ * This function scans all the connection cache entries and verifies the
+ * connections whose foreign server OID matches with the specified one. If
+ * InvalidOid is specified, it verifies all the cached connections.
+ *
+ * This function emits warnings if a disconnection is found. This returns false
+ * if disconnections are found, otherwise returns true.
+ *
+ * checked will be set to true if check_connection_health() is called at least once.
+ */
+bool
+verify_cached_connections(Oid serverid, bool *checked)
+{
+	HASH_SEQ_STATUS scan;
+	ConnCacheEntry *entry;
+	bool		all = !OidIsValid(serverid);
+	bool		result = true;
+	StringInfoData str;
+
+	*checked = false;
+
+	Assert(ConnectionHash);
+
+	hash_seq_init(&scan, ConnectionHash);
+	while ((entry = (ConnCacheEntry *) hash_seq_search(&scan)))
+	{
+		/* Ignore cache entry if no open connection right now */
+		if (!entry->conn)
+			continue;
+
+		/* Skip if the entry is invalidated */
+		if (entry->invalidated)
+			continue;
+
+		if (all || entry->serverid == serverid)
+		{
+			if (check_connection_health(entry->conn))
+			{
+				/* A foreign server might be down, so construct a message */
+				ForeignServer *server = GetForeignServer(entry->serverid);
+
+				if (result)
+				{
+					/*
+					 * Initialize and add a prefix if this is the first
+					 * disconnection we found.
+					 */
+					initStringInfo(&str);
+					appendStringInfo(&str, "could not connect to server ");
+
+					result = false;
+				}
+				else
+					appendStringInfo(&str, ", ");
+
+				appendStringInfo(&str, "\"%s\"", server->servername);
+			}
+
+			/* Set a flag to notify the caller */
+			*checked = true;
+		}
+	}
+
+	/* Raise a warning if disconnections are found */
+	if (!result)
+	{
+		Assert(str.len);
+		ereport(WARNING,
+				errcode(ERRCODE_CONNECTION_FAILURE),
+				errmsg("%s", str.data),
+				errdetail("Connection close is detected."),
+				errhint("Plsease check the health of server."));
+		pfree(str.data);
+	}
+
+	return result;
+}
+
+/*
+ * Verify the specified cached connections.
+ *
+ * This function verifies the connections that are established by postgres_fdw
+ * from the local session to the foreign server with the given name.
+ *
+ * This function emits a warning if a disconnection is found. This returns true
+ * if existing connection is not closed by the remote peer. false is returned
+ * if the local session seems to be disconnected from other servers. NULL is
+ * returned if a valid connection to the specified foreign server is not
+ * established or this function is not available on this platform.
+ */
+Datum
+pgfdw_plus_verify_connection_states(PG_FUNCTION_ARGS)
+{
+	ForeignServer *server;
+	char	   *servername;
+	bool		result;
+	bool		checked = false;
+
+	/* quick exit if the checking does not work well on this platfrom */
+	if (!connection_checkable())
+		PG_RETURN_NULL();
+
+	/* quick exit if connection cache has not been initialized yet */
+	if (!ConnectionHash)
+		PG_RETURN_NULL();
+
+	servername = text_to_cstring(PG_GETARG_TEXT_PP(0));
+	server = GetForeignServerByName(servername, false);
+
+	result = verify_cached_connections(server->serverid, &checked);
+
+	/* Return the result if checking function was called, otherwise NULL */
+	if (checked)
+		PG_RETURN_BOOL(result);
+	else
+		PG_RETURN_NULL();
+}
+
+/*
+ * Verify all the cached connections.
+ *
+ * This function verifies all the connections that are established by postgres_fdw
+ * from the local session to the foreign servers.
+ */
+Datum
+pgfdw_plus_verify_connection_states_all(PG_FUNCTION_ARGS)
+{
+	bool		result;
+	bool		checked = false;
+
+	/* quick exit if the checking does not work well on this platfrom */
+	if (!connection_checkable())
+		PG_RETURN_NULL();
+
+	/* quick exit if connection cache has not been initialized yet */
+	if (!ConnectionHash)
+		PG_RETURN_NULL();
+
+	result = verify_cached_connections(InvalidOid, &checked);
+
+	/* Return the result if checking function was called, otherwise NULL */
+	if (checked)
+		PG_RETURN_BOOL(result);
+	else
+		PG_RETURN_NULL();
+}
+
+/*
+ * Check whether functions for verifying cached connections work well or not
+ */
+Datum
+pgfdw_plus_can_verify_connection_states(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_BOOL(connection_checkable());
 }

--- a/postgres_fdw_plus.c
+++ b/postgres_fdw_plus.c
@@ -675,7 +675,8 @@ verify_cached_connections(Oid serverid, bool *checked)
  * if existing connection is not closed by the remote peer. false is returned
  * if the local session seems to be disconnected from other servers. NULL is
  * returned if a valid connection to the specified foreign server is not
- * established or this function is not available on this platform.
+ * established. If this function is not supported on this platform, this
+ * function raises an error.
  */
 Datum
 pgfdw_plus_verify_connection_states(PG_FUNCTION_ARGS)
@@ -685,9 +686,13 @@ pgfdw_plus_verify_connection_states(PG_FUNCTION_ARGS)
 	bool		result;
 	bool		checked = false;
 
-	/* quick exit if the checking does not work well on this platfrom */
+	/* raise an error if the checking does not work well on this platfrom */
 	if (!connection_checkable())
-		PG_RETURN_NULL();
+	{
+		ereport(ERROR,
+				errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				errmsg("pgfdw_plus_verify_connection_states is not supported on this platform."));
+	}
 
 	/* quick exit if connection cache has not been initialized yet */
 	if (!ConnectionHash)

--- a/postgres_fdw_plus.h
+++ b/postgres_fdw_plus.h
@@ -94,6 +94,9 @@ extern void pgfdw_finish_commit_prepared_cleanup(
 extern bool pgfdw_rollback_prepared(ConnCacheEntry *entry);
 extern void pgfdw_deallocate_all(ConnCacheEntry *entry);
 extern void pgfdw_insert_xact_commits(List *umids);
+extern bool connection_checkable(void);
+extern int check_connection_health(PGconn *conn);
+extern bool verify_cached_connections(Oid serverid, bool *checked);
 
 /*
  * Construct the prepared transaction command like PREPARE TRANSACTION

--- a/sql/postgres_fdw_plus.sql
+++ b/sql/postgres_fdw_plus.sql
@@ -365,7 +365,7 @@ SELECT 1 FROM postgres_fdw_disconnect_all();
 ALTER SERVER pgfdw_plus_loopback1 OPTIONS (SET application_name 'healthcheck');
 
 -- Define procedure for testing verify functions
-CREATE PROCEDURE test_verify_function(use_all boolean) AS $$
+DO $$
 DECLARE
 	can_verify boolean;
 	result boolean;
@@ -384,13 +384,7 @@ BEGIN
 		-- Set client_min_messages to ERROR temporary because the following
 		-- function only throws a WARNING on the supported platform.
 		SET LOCAL client_min_messages TO ERROR;
-
-		IF use_all IS TRUE THEN
-			SELECT INTO result pgfdw_plus_verify_connection_states_all();
-		ELSE
-			SELECT INTO result pgfdw_plus_verify_connection_states('pgfdw_plus_loopback1');
-		END IF;
-
+		SELECT INTO result pgfdw_plus_verify_connection_states('pgfdw_plus_loopback1');
 		RESET client_min_messages;
 	ELSE
 		result = false;
@@ -399,14 +393,10 @@ BEGIN
 	-- If result is FALSE, we succeeded to detect the disconnection or it could
 	-- not be done on this platform. Raise an message.
 	IF result IS FALSE THEN
-		RAISE INFO 'pgfdw_plus_verify_connection_states_all() could detect the disconnection, or health check cannot be used on this platform';
+		RAISE INFO 'pgfdw_plus_verify_connection_states() detected the disconnection, or health check cannot be used on this platform';
 	END IF;
 END;
 $$ LANGUAGE plpgsql;
-
--- ..And call above function
-CALL test_verify_function(false);
-CALL test_verify_function(true);
 
 -- Clean up
 \set VERBOSITY default

--- a/sql/postgres_fdw_plus.sql
+++ b/sql/postgres_fdw_plus.sql
@@ -354,6 +354,64 @@ SELECT count(*) FROM pgfdw_plus_resolve_foreign_prepared_xacts_all();
 SELECT count(*) FROM pgfdw_plus_vacuum_xact_commits();
 
 -- ===================================================================
+-- test for pgfdw_plus_verify_connection_states function
+-- ===================================================================
+
+-- -- The text of the error might vary across platforms, so only show SQLSTATE.
+\set VERBOSITY sqlstate
+
+-- Disconnect once and set application_name to an arbitrary value
+SELECT 1 FROM postgres_fdw_disconnect_all();
+ALTER SERVER pgfdw_plus_loopback1 OPTIONS (SET application_name 'healthcheck');
+
+-- Define procedure for testing verify functions
+CREATE PROCEDURE test_verify_function(use_all boolean) AS $$
+DECLARE
+	can_verify boolean;
+	result boolean;
+BEGIN
+	PERFORM 1 FROM ft1 LIMIT 1;
+
+	-- Terminate the remote backend process
+	PERFORM pg_terminate_backend(pid, 180000) FROM pg_stat_activity
+		WHERE application_name = 'healthcheck';
+
+	-- Check whether we can do health check on this platform
+	SELECT INTO can_verify pgfdw_plus_can_verify_connection_states();
+
+	-- If the checking can be done on this platform, call it
+	IF can_verify IS TRUE THEN
+		-- Set client_min_messages to ERROR temporary because the following
+		-- function only throws a WARNING on the supported platform.
+		SET LOCAL client_min_messages TO ERROR;
+
+		IF use_all IS TRUE THEN
+			SELECT INTO result pgfdw_plus_verify_connection_states_all();
+		ELSE
+			SELECT INTO result pgfdw_plus_verify_connection_states('pgfdw_plus_loopback1');
+		END IF;
+
+		RESET client_min_messages;
+	ELSE
+		result = false;
+	END IF;
+
+	-- If result is FALSE, we succeeded to detect the disconnection or it could
+	-- not be done on this platform. Raise an message.
+	IF result IS FALSE THEN
+		RAISE INFO 'pgfdw_plus_verify_connection_states_all() could detect the disconnection, or health check cannot be used on this platform';
+	END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ..And call above function
+CALL test_verify_function(false);
+CALL test_verify_function(true);
+
+-- Clean up
+\set VERBOSITY default
+
+-- ===================================================================
 -- Reset global settings
 -- ===================================================================
 RESET postgres_fdw.two_phase_commit;


### PR DESCRIPTION
## Background
A transaction that touches foreign servers fails to commit if the transaction loses a connection to a server.
It is better that a transaction notices the disconnection early and abort to avoid wasted work.
Currently, we do not have a way to detect a disconnection by a foreign server.
A transaction notices a disconnection only when it actually tries to connect a server (e.g. commit phase).

## This PR
This PR adds functions that check the health of a connection to a foreign server.
These functions can check whether an existing connection is closed by a remote peer.
With this function, we can detect a disconnection by a foreign server early and abort a transaction to avoid wasted work.

## Note
This feature is the same as the one proposed in the PostgreSQL community
(https://www.postgresql.org/message-id/TYAPR01MB58662809E678253B90E82CE5F5889%40TYAPR01MB5866.jpnprd01.prod.outlook.com). 
This PR reused the patch but modified it a little bit for postgres_fdw_plus.
The Followings are the main points of the modifications:
* The function names are changed to pgfdw_plus_... (not postgres_fdw_...).
* Tests are added to the postgres_fdw_plus part.
* Polling is implemented in the postgres_fdw_plus/connection.c, not in the libpq