### PR TITLE
Fix a bug when parallel commit is on

### DIFF
--- a/expected/postgres_fdw_plus.out
+++ b/expected/postgres_fdw_plus.out
@@ -38,7 +38,8 @@ DO $d$
             FOREIGN DATA WRAPPER postgres_fdw
             OPTIONS (dbname '$$||current_database()||$$',
                      port '$$||current_setting('port')||$$',
-                     application_name 'pgfdw_plus_loopback2'
+                     application_name 'pgfdw_plus_loopback2',
+					 parallel_commit 'on'
             )$$;
     END;
 $d$;

--- a/expected/postgres_fdw_plus.out
+++ b/expected/postgres_fdw_plus.out
@@ -39,7 +39,7 @@ DO $d$
             OPTIONS (dbname '$$||current_database()||$$',
                      port '$$||current_setting('port')||$$',
                      application_name 'pgfdw_plus_loopback2',
-					 parallel_commit 'on'
+                     parallel_commit 'on'
             )$$;
     END;
 $d$;

--- a/postgres_fdw_plus.c
+++ b/postgres_fdw_plus.c
@@ -385,6 +385,16 @@ pgfdw_commit_prepared(ConnCacheEntry *entry,
 	 */
 	if (success)
 		pgfdw_deallocate_all(entry);
+
+	/*
+	 * If parallel_commit and pgfdw_skip_commit_phase are true, this connection
+	 * cache entry will not be used in this transaction.
+	 */
+	if (entry->parallel_commit && pgfdw_skip_commit_phase)
+	{
+		entry->fxid = InvalidFullTransactionId;
+		pgfdw_reset_xact_state(entry, true);
+	}
 }
 
 void

--- a/postgres_fdw_plus.c
+++ b/postgres_fdw_plus.c
@@ -257,6 +257,8 @@ pgfdw_xact_two_phase(XactEvent event)
 				case XACT_EVENT_COMMIT:
 					pgfdw_commit_prepared(entry,
 										  &pending_entries_commit_prepared);
+					if (entry->parallel_commit)
+						continue;
 					break;
 
 				case XACT_EVENT_PARALLEL_ABORT:
@@ -408,6 +410,9 @@ pgfdw_finish_commit_prepared_cleanup(List *pending_entries_commit_prepared)
 
 		if (success)
 			pgfdw_deallocate_all(entry);
+
+		entry->fxid = InvalidFullTransactionId;
+		pgfdw_reset_xact_state(entry, true);
 	}
 }
 

--- a/postgres_fdw_plus.c
+++ b/postgres_fdw_plus.c
@@ -257,7 +257,7 @@ pgfdw_xact_two_phase(XactEvent event)
 				case XACT_EVENT_COMMIT:
 					pgfdw_commit_prepared(entry,
 										  &pending_entries_commit_prepared);
-					if (entry->parallel_commit)
+					if (entry->parallel_commit && !pgfdw_skip_commit_phase)
 						continue;
 					break;
 
@@ -385,16 +385,6 @@ pgfdw_commit_prepared(ConnCacheEntry *entry,
 	 */
 	if (success)
 		pgfdw_deallocate_all(entry);
-
-	/*
-	 * If parallel_commit and pgfdw_skip_commit_phase are true, this connection
-	 * cache entry will not be used in this transaction.
-	 */
-	if (entry->parallel_commit && pgfdw_skip_commit_phase)
-	{
-		entry->fxid = InvalidFullTransactionId;
-		pgfdw_reset_xact_state(entry, true);
-	}
 }
 
 void

--- a/sql/postgres_fdw_plus.sql
+++ b/sql/postgres_fdw_plus.sql
@@ -43,7 +43,8 @@ DO $d$
             FOREIGN DATA WRAPPER postgres_fdw
             OPTIONS (dbname '$$||current_database()||$$',
                      port '$$||current_setting('port')||$$',
-                     application_name 'pgfdw_plus_loopback2'
+                     application_name 'pgfdw_plus_loopback2',
+					 parallel_commit 'on'
             )$$;
     END;
 $d$;

--- a/sql/postgres_fdw_plus.sql
+++ b/sql/postgres_fdw_plus.sql
@@ -44,7 +44,7 @@ DO $d$
             OPTIONS (dbname '$$||current_database()||$$',
                      port '$$||current_setting('port')||$$',
                      application_name 'pgfdw_plus_loopback2',
-					 parallel_commit 'on'
+                     parallel_commit 'on'
             )$$;
     END;
 $d$;


### PR DESCRIPTION
This commit fixes the timing of calling pgfdw_reset_xact_state when parallel commit is on.

Previously pgfdw_reset_xact_state was called before pgfdw_finish_commit_prepared_cleanup when parallel commit was on. Therefore, connections were not usable in pgfdw_finish_commit_prepared_cleanup and warning was raised.

Reported-by: Etsuro Fujita
Author: Etsuro Fujita