### PR TITLE
Allow postgres_fdw_plus to use read committed for remote transactions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,24 @@ This setting has no effect if postgres_fdw.two_phase_commit is false.
 
 Any users can change this setting.
 
+### postgres_fdw.use_read_committed (boolean)
+If false (default), remote transactions are started with either serializable
+or repeatable read isolation level, similar to postgres_fdw. However,
+if true, remote transactions will start with the read committed isolation
+level if the local transaction starts with the read committed.
+
+It is important to note that when using the read committed for remote
+transactions, multiple foreign scans in a single query are not allowed to
+ensure the query's result is consistent. If multiple foreign scans occur,
+the query fails with an error.
+
+Any users can change this setting. However, the decision to use
+the read committed for remote transactions is determined based on
+the value of the postgres_fdw.use_read_committed parameter
+when the first remote transaction is started in a local transaction.
+This decision remains the same throughout the local transaction,
+even if the postgres_fdw.use_read_committed is changed during that time. 
+
 ## Functions
 
 ### SETOF resolve_foreign_prepared_xacts pgfdw_plus_resolve_foreign_prepared_xacts (server name, force boolean)

--- a/connection.c
+++ b/connection.c
@@ -211,6 +211,8 @@ GetConnection(UserMapping *user, bool will_prep_stmt, PgFdwConnState **state)
 									  pgfdw_inval_callback, (Datum) 0);
 	}
 
+	pgfdw_arrange_read_committed(xact_got_connection);
+
 	/* Set flag that we did GetConnection during the current transaction */
 	xact_got_connection = true;
 
@@ -758,6 +760,8 @@ begin_remote_xact(ConnCacheEntry *entry)
 			sql = "START TRANSACTION ISOLATION LEVEL SERIALIZABLE";
 		else
 			sql = "START TRANSACTION ISOLATION LEVEL REPEATABLE READ";
+		if (pgfdw_use_read_committed_in_xact && !IsolationUsesXactSnapshot())
+			sql = "START TRANSACTION ISOLATION LEVEL READ COMMITTED";
 		entry->changing_xact_state = true;
 		do_sql_command(entry->conn, sql);
 		entry->xact_depth = 1;

--- a/expected/postgres_fdw_plus.out
+++ b/expected/postgres_fdw_plus.out
@@ -74,6 +74,32 @@ CREATE FOREIGN TABLE ft2 (c1 int) SERVER pgfdw_plus_loopback2
 CREATE VIEW ftv AS SELECT * FROM t0 UNION ALL
   SELECT * FROM ft1 UNION ALL SELECT * FROM ft2;
 -- ===================================================================
+-- Test postgres_fdw.use_read_committed
+-- ===================================================================
+SET postgres_fdw.use_read_committed TO off;
+SELECT * FROM ft1, ft2;
+ c1 | c1 
+----+----
+(0 rows)
+
+SET postgres_fdw.use_read_committed TO on;
+SELECT * FROM ft1, ft2;
+ERROR:  could not initiate multiple foreign scans in a single query
+DETAIL:  Multiple foreign scans are not allowed in a single query when using read committed level for remote transactions to maintain consistency.
+HINT:  Disable postgres_fdw.use_read_committed or modify query to perform only a single foreign scan.
+BEGIN;
+SELECT * FROM ft1;
+ c1 
+----
+(0 rows)
+
+SET postgres_fdw.use_read_committed TO off;
+SELECT * FROM ft1 WHERE c1 IN (SELECT c1 FROM ft1);
+ERROR:  could not initiate multiple foreign scans in a single query
+DETAIL:  Multiple foreign scans are not allowed in a single query when using read committed level for remote transactions to maintain consistency.
+HINT:  Disable postgres_fdw.use_read_committed or modify query to perform only a single foreign scan.
+COMMIT;
+-- ===================================================================
 -- Test two phase commit
 -- ===================================================================
 SET postgres_fdw.two_phase_commit TO true;
@@ -97,12 +123,15 @@ SELECT * FROM pg_prepared_xacts;
 -------------+-----+----------+-------+----------
 (0 rows)
 
+BEGIN;
+SET LOCAL postgres_fdw.use_read_committed TO off;
 SELECT count(*) FROM ftv WHERE c1 = 100;
  count 
 -------
      3
 (1 row)
 
+COMMIT;
 SELECT array_length(umids, 1) FROM pgfdw_plus.xact_commits ORDER BY fxid;
  array_length 
 --------------
@@ -130,12 +159,15 @@ SELECT * FROM pg_prepared_xacts;
 -------------+-----+----------+-------+----------
 (0 rows)
 
+BEGIN;
+SET LOCAL postgres_fdw.use_read_committed TO off;
 SELECT count(*) FROM ftv WHERE c1 = 110;
  count 
 -------
      0
 (1 row)
 
+COMMIT;
 SELECT array_length(umids, 1) FROM pgfdw_plus.xact_commits ORDER BY fxid;
  array_length 
 --------------
@@ -174,12 +206,15 @@ SELECT * FROM pg_prepared_xacts;
 -------------+-----+----------+-------+----------
 (0 rows)
 
+BEGIN;
+SET LOCAL postgres_fdw.use_read_committed TO off;
 SELECT count(*) FROM ftv WHERE c1 = 120;
  count 
 -------
      0
 (1 row)
 
+COMMIT;
 SELECT array_length(umids, 1) FROM pgfdw_plus.xact_commits ORDER BY fxid;
  array_length 
 --------------
@@ -219,12 +254,15 @@ SELECT * FROM pg_prepared_xacts;
 -------------+-----+----------+-------+----------
 (0 rows)
 
+BEGIN;
+SET LOCAL postgres_fdw.use_read_committed TO off;
 SELECT count(*) FROM ftv WHERE c1 = 130;
  count 
 -------
      0
 (1 row)
 
+COMMIT;
 SELECT array_length(umids, 1) FROM pgfdw_plus.xact_commits ORDER BY fxid;
  array_length 
 --------------

--- a/postgres_fdw_plus.h
+++ b/postgres_fdw_plus.h
@@ -13,6 +13,13 @@
 extern bool pgfdw_two_phase_commit;
 extern bool pgfdw_skip_commit_phase;
 extern bool pgfdw_track_xact_commits;
+extern bool pgfdw_use_read_committed;
+
+/*
+ * Global variables
+ */
+extern bool pgfdw_use_read_committed_in_xact;
+extern CommandId pgfdw_last_cid;
 
 /*
  * Connection cache hash table entry
@@ -104,6 +111,7 @@ extern void pgfdw_abort_cleanup(ConnCacheEntry *entry, bool toplevel);
 extern void pgfdw_abort_cleanup_with_sql(ConnCacheEntry *entry,
 										 const char *sql, bool toplevel);
 
+extern void pgfdw_arrange_read_committed(bool xact_got_connection);
 extern bool pgfdw_xact_two_phase(XactEvent event);
 extern void pgfdw_prepare_xacts(ConnCacheEntry *entry,
 								List **pending_entries_prepare);


### PR DESCRIPTION
This commit introduces a new parameter, postgres_fdw.use_read_committed, which controls the isolation level used when starting a remote transaction. By default, the parameter is disabled, and remote transactions start with either serializable or repeatable read isolation level to ensure consistency when fetching results from foreign scans.

With this commit, when postgres_fdw.use_read_committed is enabled, remote transactions start with the read committed isolation level. However, multiple foreign scans in a single query are disallowed to maintain consistency.

This update improves postgres_fdw_plus and makes it more flexible, allowing users to select the appropriate isolation level for their needs.