### PR TITLE
Fix to send ROLLBACK PREPARED when parallel_commit is on

### DIFF
--- a/expected/postgres_fdw_plus.out
+++ b/expected/postgres_fdw_plus.out
@@ -454,52 +454,12 @@ SELECT count(*) FROM pgfdw_plus.xact_commits;
      1
 (1 row)
 
--- Resolve another prepared transaction to keep the number of prepared transactions
--- below max_prepared_xacts
-SELECT status, count(*)
-  FROM pgfdw_plus_resolve_foreign_prepared_xacts('pgfdw_plus_loopback2')
-  GROUP BY status ORDER BY status;
-  status   | count 
------------+-------
- committed |     1
-(1 row)
-
-SELECT count(*) FROM pgfdw_plus_foreign_prepared_xacts('pgfdw_plus_loopback1');
- count 
--------
-     0
-(1 row)
-
-SELECT count(*) FROM pgfdw_plus_foreign_prepared_xacts('pgfdw_plus_loopback2');
- count 
--------
-     0
-(1 row)
-
--- Create two foreign prepared transactions that should be rollbacked
+-- Create one foreign prepared transaction that should be rollbacked
 -- so as to test later whether pgfdw_plus_resolve_foreign_prepared_xacts_all()
--- can actually rollback them.
--- Temporarily set parallel_commit to 'on' in pgfdw_plus_loopaback1 to surely
--- create prepared transactions.
-ALTER SERVER pgfdw_plus_loopback1 OPTIONS (add parallel_commit 'on');
+-- can actually rollback it.
 BEGIN;
 INSERT INTO ft1 VALUES (210);
 INSERT INTO ft2 VALUES (210);
-SELECT pg_terminate_backend(pid, 10000) FROM pg_stat_activity
-    WHERE application_name = 'pgfdw_plus_loopback1';
- pg_terminate_backend 
-----------------------
- t
-(1 row)
-
-COMMIT;
-ERROR:  FATAL:  terminating connection due to administrator command
-server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
-BEGIN;
-INSERT INTO ft1 VALUES (220);
-INSERT INTO ft2 VALUES (220);
 SELECT pg_terminate_backend(pid, 10000) FROM pg_stat_activity
     WHERE application_name = 'pgfdw_plus_loopback2';
  pg_terminate_backend 
@@ -512,15 +472,15 @@ ERROR:  FATAL:  terminating connection due to administrator command
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
-ALTER SERVER pgfdw_plus_loopback1 OPTIONS (drop parallel_commit);
 -- All foreign prepared transactions are resolved and xact_commits
 -- should be empty.
 SELECT status, count(*) FROM pgfdw_plus_resolve_foreign_prepared_xacts_all()
   GROUP BY status ORDER BY status;
- status  | count 
----------+-------
- aborted |     2
-(1 row)
+  status   | count 
+-----------+-------
+ aborted   |     1
+ committed |     1
+(2 rows)
 
 SELECT count(*) FROM pgfdw_plus_foreign_prepared_xacts('pgfdw_plus_loopback1');
  count 

--- a/expected/postgres_fdw_plus.out
+++ b/expected/postgres_fdw_plus.out
@@ -38,7 +38,8 @@ DO $d$
             FOREIGN DATA WRAPPER postgres_fdw
             OPTIONS (dbname '$$||current_database()||$$',
                      port '$$||current_setting('port')||$$',
-                     application_name 'pgfdw_plus_loopback2'
+                     application_name 'pgfdw_plus_loopback2',
+                     parallel_commit 'on'
             )$$;
     END;
 $d$;
@@ -453,9 +454,34 @@ SELECT count(*) FROM pgfdw_plus.xact_commits;
      1
 (1 row)
 
--- Create one foreign prepared transaction that should be rollbacked
+-- Resolve another prepared transaction to keep the number of prepared transactions
+-- below max_prepared_xacts
+SELECT status, count(*)
+  FROM pgfdw_plus_resolve_foreign_prepared_xacts('pgfdw_plus_loopback2')
+  GROUP BY status ORDER BY status;
+  status   | count 
+-----------+-------
+ committed |     1
+(1 row)
+
+SELECT count(*) FROM pgfdw_plus_foreign_prepared_xacts('pgfdw_plus_loopback1');
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM pgfdw_plus_foreign_prepared_xacts('pgfdw_plus_loopback2');
+ count 
+-------
+     0
+(1 row)
+
+-- Create two foreign prepared transactions that should be rollbacked
 -- so as to test later whether pgfdw_plus_resolve_foreign_prepared_xacts_all()
--- can actually rollback it.
+-- can actually rollback them.
+-- Temporarily set parallel_commit to 'on' in pgfdw_plus_loopaback1 to surely
+-- create prepared transactions.
+ALTER SERVER pgfdw_plus_loopback1 OPTIONS (add parallel_commit 'on');
 BEGIN;
 INSERT INTO ft1 VALUES (210);
 INSERT INTO ft2 VALUES (210);
@@ -486,15 +512,15 @@ ERROR:  FATAL:  terminating connection due to administrator command
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
+ALTER SERVER pgfdw_plus_loopback1 OPTIONS (drop parallel_commit);
 -- All foreign prepared transactions are resolved and xact_commits
 -- should be empty.
 SELECT status, count(*) FROM pgfdw_plus_resolve_foreign_prepared_xacts_all()
   GROUP BY status ORDER BY status;
-  status   | count 
------------+-------
- aborted   |     1
- committed |     1
-(2 rows)
+ status  | count 
+---------+-------
+ aborted |     2
+(1 row)
 
 SELECT count(*) FROM pgfdw_plus_foreign_prepared_xacts('pgfdw_plus_loopback1');
  count 

--- a/postgres_fdw_plus.c
+++ b/postgres_fdw_plus.c
@@ -229,13 +229,16 @@ pgfdw_xact_two_phase(XactEvent event)
 		case XACT_EVENT_PRE_PREPARE:
 		case XACT_EVENT_PREPARE:
 			return false;
-		/* Entries in the pending_entries_prepare are parallel_commit=on and
+		/*
+		 * Entries in the pending_entries_prepare are parallel_commit=on and
 		 * have already sent PREPARE TRANSACTION, however, PQgetResult might
 		 * still not be called to some of them. It is necessary to call
 		 * PQgetResult before sending ROLLBACK PREPARED.
 		 */
 		case XACT_EVENT_ABORT:
 		case XACT_EVENT_PARALLEL_ABORT:
+			if (!pgfdw_two_phase_commit)
+				return false;
 			if (pending_entries_prepare)
 				pgfdw_cleanup_pending_entries(pending_entries_prepare);
 			break;

--- a/postgres_fdw_plus.h
+++ b/postgres_fdw_plus.h
@@ -116,7 +116,6 @@ extern bool pgfdw_xact_two_phase(XactEvent event);
 extern void pgfdw_prepare_xacts(ConnCacheEntry *entry,
 								List **pending_entries_prepare);
 extern void pgfdw_finish_prepare_cleanup(List **pending_entries_prepare);
-extern void pgfdw_cleanup_pending_entries(List **pending_entries_prepare);
 extern void pgfdw_commit_prepared(ConnCacheEntry *entry,
 								  List **pending_entries_commit_prepared);
 extern void pgfdw_finish_commit_prepared_cleanup(

--- a/postgres_fdw_plus.h
+++ b/postgres_fdw_plus.h
@@ -115,8 +115,8 @@ extern void pgfdw_arrange_read_committed(bool xact_got_connection);
 extern bool pgfdw_xact_two_phase(XactEvent event);
 extern void pgfdw_prepare_xacts(ConnCacheEntry *entry,
 								List **pending_entries_prepare);
-extern void pgfdw_finish_prepare_cleanup(List *pending_entries_prepare);
-extern void pgfdw_cleanup_pending_entries(List *pending_entries_prepare);
+extern void pgfdw_finish_prepare_cleanup(List **pending_entries_prepare);
+extern void pgfdw_cleanup_pending_entries(List **pending_entries_prepare);
 extern void pgfdw_commit_prepared(ConnCacheEntry *entry,
 								  List **pending_entries_commit_prepared);
 extern void pgfdw_finish_commit_prepared_cleanup(

--- a/postgres_fdw_plus.h
+++ b/postgres_fdw_plus.h
@@ -113,9 +113,10 @@ extern void pgfdw_abort_cleanup_with_sql(ConnCacheEntry *entry,
 
 extern void pgfdw_arrange_read_committed(bool xact_got_connection);
 extern bool pgfdw_xact_two_phase(XactEvent event);
-extern void pgfdw_prepare_xacts(ConnCacheEntry *entry);
-extern void pgfdw_finish_prepare_cleanup(void);
-extern void pgfdw_cleanup_pending_entries(void);
+extern void pgfdw_prepare_xacts(ConnCacheEntry *entry,
+								List **pending_entries_prepare);
+extern void pgfdw_finish_prepare_cleanup(List *pending_entries_prepare);
+extern void pgfdw_cleanup_pending_entries(List *pending_entries_prepare);
 extern void pgfdw_commit_prepared(ConnCacheEntry *entry,
 								  List **pending_entries_commit_prepared);
 extern void pgfdw_finish_commit_prepared_cleanup(

--- a/postgres_fdw_plus.h
+++ b/postgres_fdw_plus.h
@@ -113,9 +113,9 @@ extern void pgfdw_abort_cleanup_with_sql(ConnCacheEntry *entry,
 
 extern void pgfdw_arrange_read_committed(bool xact_got_connection);
 extern bool pgfdw_xact_two_phase(XactEvent event);
-extern void pgfdw_prepare_xacts(ConnCacheEntry *entry,
-								List **pending_entries_prepare);
-extern void pgfdw_finish_prepare_cleanup(List *pending_entries_prepare);
+extern void pgfdw_prepare_xacts(ConnCacheEntry *entry);
+extern void pgfdw_finish_prepare_cleanup(void);
+extern void pgfdw_cleanup_pending_entries(void);
 extern void pgfdw_commit_prepared(ConnCacheEntry *entry,
 								  List **pending_entries_commit_prepared);
 extern void pgfdw_finish_commit_prepared_cleanup(

--- a/sql/postgres_fdw_plus.sql
+++ b/sql/postgres_fdw_plus.sql
@@ -251,33 +251,15 @@ SELECT count(*) FROM pgfdw_plus_foreign_prepared_xacts('pgfdw_plus_loopback2');
 SELECT count(*) FROM pgfdw_plus_vacuum_xact_commits();
 SELECT count(*) FROM pgfdw_plus.xact_commits;
 
--- Resolve another prepared transaction to keep the number of prepared transactions
--- below max_prepared_xacts
-SELECT status, count(*)
-  FROM pgfdw_plus_resolve_foreign_prepared_xacts('pgfdw_plus_loopback2')
-  GROUP BY status ORDER BY status;
-SELECT count(*) FROM pgfdw_plus_foreign_prepared_xacts('pgfdw_plus_loopback1');
-SELECT count(*) FROM pgfdw_plus_foreign_prepared_xacts('pgfdw_plus_loopback2');
-
--- Create two foreign prepared transactions that should be rollbacked
+-- Create one foreign prepared transaction that should be rollbacked
 -- so as to test later whether pgfdw_plus_resolve_foreign_prepared_xacts_all()
--- can actually rollback them.
--- Temporarily set parallel_commit to 'on' in pgfdw_plus_loopaback1 to surely
--- create prepared transactions.
-ALTER SERVER pgfdw_plus_loopback1 OPTIONS (add parallel_commit 'on');
+-- can actually rollback it.
 BEGIN;
 INSERT INTO ft1 VALUES (210);
 INSERT INTO ft2 VALUES (210);
 SELECT pg_terminate_backend(pid, 10000) FROM pg_stat_activity
-    WHERE application_name = 'pgfdw_plus_loopback1';
-COMMIT;
-BEGIN;
-INSERT INTO ft1 VALUES (220);
-INSERT INTO ft2 VALUES (220);
-SELECT pg_terminate_backend(pid, 10000) FROM pg_stat_activity
     WHERE application_name = 'pgfdw_plus_loopback2';
 COMMIT;
-ALTER SERVER pgfdw_plus_loopback1 OPTIONS (drop parallel_commit);
 
 -- All foreign prepared transactions are resolved and xact_commits
 -- should be empty.


### PR DESCRIPTION
On a transaction abort, the current implementation might not send ROLLBACK PREPARED to those connections that have sent PREPARED TRANSACTION with parallel_commit=on.
Because PQgetResult for PREPARED TRANSACTION is not called and xact_changing_state is true for those connecctions, pgfdw_abort_cleanup_with_sql skips to send ROLLBACK PREPARED.

This PR fixes this by cleaning up the pending_entries_prepare at the beginning of the abort process of pgfdw_xact_two_phase. Along with this fix on parallel commit, this PR fixes the regression test to keep the number of prepared transactions below max_prepared_xacts.