### PR TITLE
Add support for parallel_abort to ABORT/ROLLBACK command

### DIFF
--- a/connection.c
+++ b/connection.c
@@ -151,16 +151,18 @@ static bool pgfdw_exec_cleanup_query_end(PGconn *conn, const char *query,
 static bool pgfdw_get_cleanup_result(PGconn *conn, TimestampTz endtime,
 									 PGresult **result, bool *timed_out);
 static void pgfdw_abort_cleanup(ConnCacheEntry *entry, bool toplevel);
-#endif	/* NOT_USED_IN_PGFDWPLUS */
 static bool pgfdw_abort_cleanup_begin(ConnCacheEntry *entry, bool toplevel,
 									  List **pending_entries,
 									  List **cancel_requested);
+#endif	/* NOT_USED_IN_PGFDWPLUS */
 static void pgfdw_finish_pre_commit_cleanup(List *pending_entries);
 static void pgfdw_finish_pre_subcommit_cleanup(List *pending_entries,
 											   int curlevel);
+#ifdef NOT_USED_IN_PGFDWPLUS
 static void pgfdw_finish_abort_cleanup(List *pending_entries,
 									   List *cancel_requested,
 									   bool toplevel);
+#endif	/* NOT_USED_IN_PGFDWPLUS */
 static void pgfdw_security_check(const char **keywords, const char **values,
 								 UserMapping *user, PGconn *conn);
 static bool UserMappingPasswordRequired(UserMapping *user);
@@ -1749,7 +1751,10 @@ pgfdw_abort_cleanup(ConnCacheEntry *entry, bool toplevel)
  * connection cache entry is appended to *pending_entries.  Otherwise, if the
  * cancel request is successfully issued, it is appended to *cancel_requested.
  */
+#ifdef NOT_USED_IN_PGFDWPLUS
 static bool
+#endif	/* NOT_USED_IN_PGFDWPLUS */
+bool
 pgfdw_abort_cleanup_begin(ConnCacheEntry *entry, bool toplevel,
 						  List **pending_entries, List **cancel_requested)
 {
@@ -1911,7 +1916,10 @@ pgfdw_finish_pre_subcommit_cleanup(List *pending_entries, int curlevel)
  * Finish abort cleanup of connections on each of which we've sent an abort
  * command or cancel request to the remote server.
  */
+#ifdef NOT_USED_IN_PGFDWPLUS
 static void
+#endif	/* NOT_USED_IN_PGFDWPLUS */
+void
 pgfdw_finish_abort_cleanup(List *pending_entries, List *cancel_requested,
 						   bool toplevel)
 {

--- a/expected/postgres_fdw_plus.out
+++ b/expected/postgres_fdw_plus.out
@@ -39,7 +39,8 @@ DO $d$
             OPTIONS (dbname '$$||current_database()||$$',
                      port '$$||current_setting('port')||$$',
                      application_name 'pgfdw_plus_loopback2',
-                     parallel_commit 'on'
+                     parallel_commit 'on',
+                     parallel_abort 'on'
             )$$;
     END;
 $d$;

--- a/postgres_fdw_plus.h
+++ b/postgres_fdw_plus.h
@@ -110,6 +110,12 @@ extern bool pgfdw_get_cleanup_result(PGconn *conn, TimestampTz endtime,
 extern void pgfdw_abort_cleanup(ConnCacheEntry *entry, bool toplevel);
 extern void pgfdw_abort_cleanup_with_sql(ConnCacheEntry *entry,
 										 const char *sql, bool toplevel);
+extern bool pgfdw_abort_cleanup_begin(ConnCacheEntry *entry, bool toplevel,
+									  List **pending_entries,
+									  List **cancel_requested);
+extern void pgfdw_finish_abort_cleanup(List *pending_entries,
+									   List *cancel_requested,
+									   bool toplevel);
 
 extern void pgfdw_arrange_read_committed(bool xact_got_connection);
 extern bool pgfdw_xact_two_phase(XactEvent event);

--- a/sql/postgres_fdw_plus.sql
+++ b/sql/postgres_fdw_plus.sql
@@ -44,7 +44,8 @@ DO $d$
             OPTIONS (dbname '$$||current_database()||$$',
                      port '$$||current_setting('port')||$$',
                      application_name 'pgfdw_plus_loopback2',
-                     parallel_commit 'on'
+                     parallel_commit 'on',
+                     parallel_abort 'on'
             )$$;
     END;
 $d$;


### PR DESCRIPTION
This PR adds support for parallel_abort.
parallel_abort has been added to postgres_fdw however postgres_fdw_plus does not support this now.

This PR does not adds parallel_abort support to ROLLBACK PREPARED.